### PR TITLE
Paragraph ended before \MT@prot@l fixed

### DIFF
--- a/pdf.yaml
+++ b/pdf.yaml
@@ -4,6 +4,8 @@ fontsize: 14pt
 geometry: margin=2cm
 biblatexoptions: [backend=biber]
 header-includes: |
+    \usepackage{microtype}
+    \microtypesetup{nopatch=item}
     \usepackage{fontspec}
     \usepackage{polyglossia}
     \usepackage{unicode-math}


### PR DESCRIPTION
Без добавленных строчек при сборке возникала ошибка ! Paragraph ended before \MT@prot@l
Информация для исправления ошибки была взята отсюда https://github.com/yihui/tinytex/issues/347