### PR TITLE
fix: Simplify mdbook.py

### DIFF
--- a/makefile
+++ b/makefile
@@ -68,7 +68,7 @@ web:
 	$(MKSRC)
 	tools/pandoc.exe $(MD) $(SITE_OPTIONS)
 	$(MOVE) $(MDBOOK_IMG) $(MDBOOK_SRC)
-	python tools/mdbook.py $(MDBOOK_SRC)/$(NAME).md $(MDBOOK_IMG) Spisok-literatury.md
+	python tools/mdbook.py $(MDBOOK_SRC)/$(NAME).md Spisok-literatury.md
 	tools/mdbook.exe build
 
 serve: web

--- a/makefile
+++ b/makefile
@@ -36,6 +36,7 @@ SITE_OPTIONS = $(BASE_OPTIONS) \
 	--extract-media=$(MDBOOK_IMG) \
 	--output=$(MDBOOK_SRC)/$(NAME).md \
 	--to=markdown-citations-implicit_figures+hard_line_breaks-pipe_tables-simple_tables-multiline_tables-grid_tables \
+	-M biburl=Spisok-literatury.md \
 	-M lang:ru
 
 ifeq ($(OS), Windows_NT)
@@ -68,7 +69,7 @@ web:
 	$(MKSRC)
 	tools/pandoc.exe $(MD) $(SITE_OPTIONS)
 	$(MOVE) $(MDBOOK_IMG) $(MDBOOK_SRC)
-	python tools/mdbook.py $(MDBOOK_SRC)/$(NAME).md Spisok-literatury.md
+	python tools/mdbook.py $(MDBOOK_SRC)/$(NAME).md
 	tools/mdbook.exe build
 
 serve: web

--- a/tools/mdbook.lua
+++ b/tools/mdbook.lua
@@ -1,3 +1,15 @@
+function Meta(meta)
+    biburl = meta.biburl
+    return meta
+end
+
+function Link(el)
+    if el.target:match '^#' then
+        el.target = biburl .. el.target
+    end
+    return el
+end
+
 function Math(m)
     -- MdBook uses \( x \) notation instead of $ x $ for inline math.
     if m.mathtype == "InlineMath" then
@@ -19,3 +31,8 @@ function Div(el)
     end
     return el
 end
+
+return {
+  { Meta = Meta },
+  { Link = Link, Math = Math, Div = Div }
+}

--- a/tools/mdbook.py
+++ b/tools/mdbook.py
@@ -1,21 +1,7 @@
 import typing
 import os
 import sys
-import re
 import iuliia
-
-
-def overwrite(fname, rewrite):
-    with open(fname, 'r+', encoding='utf-8') as file:
-        content = file.read()
-        content = rewrite(content)
-        file.seek(0)
-        file.write(content)
-        file.truncate()
-
-
-def link_citations_to_url(md, bib_url):
-    return re.sub(r'\[([0-9]+)\]\(#([^)]+)\)', rf'[\1]({bib_url}#\2)', md)
 
 
 class Section(typing.NamedTuple):
@@ -100,12 +86,7 @@ def dump_sections(sections, dirname):
     dump_file(Section('SUMMARY', body), dirname)
 
 
-source = sys.argv[1]
-biburl = sys.argv[2]
-mdbook = os.path.dirname(source)
-
-overwrite(source, lambda md: link_citations_to_url(md, biburl))
-
-sections = make_sections(source)
+book = sys.argv[1]
+sections = make_sections(book)
 sections = cleanup_sections(sections)
-dump_sections(sections, mdbook)
+dump_sections(sections, os.path.dirname(book))

--- a/tools/mdbook.py
+++ b/tools/mdbook.py
@@ -14,17 +14,6 @@ def overwrite(fname, rewrite):
         file.truncate()
 
 
-def add_extension_to_svg_images(dirname):
-    for name in os.listdir(dirname):
-        if re.match(r'^[a-f0-9]{40}$', name):
-            path = os.path.join(dirname, name)
-            os.rename(path, path + '.svg')
-
-
-def add_extension_to_svg_image_references(md, i):
-    return re.sub(rf'src="{i}/([a-f0-9]{{{40}}})"', rf'src="{i}/\1.svg"', md)
-
-
 def link_citations_to_url(md, bib_url):
     return re.sub(r'\[([0-9]+)\]\(#([^)]+)\)', rf'[\1]({bib_url}#\2)', md)
 
@@ -112,12 +101,9 @@ def dump_sections(sections, dirname):
 
 
 source = sys.argv[1]
-imgdir = sys.argv[2]
-biburl = sys.argv[3]
+biburl = sys.argv[2]
 mdbook = os.path.dirname(source)
 
-add_extension_to_svg_images(os.path.join(mdbook, imgdir))
-overwrite(source, lambda md: add_extension_to_svg_image_references(md, imgdir))
 overwrite(source, lambda md: link_citations_to_url(md, biburl))
 
 sections = make_sections(source)

--- a/tools/pysvg.lua
+++ b/tools/pysvg.lua
@@ -66,7 +66,7 @@ end
 function CodeBlock(el)
     if el.attr.classes[1] == "pysvg" then
         local data = pandoc.pipe("python", {"-"}, "from tools.pysvg import *\n" .. el.text)
-        local fname = pandoc.sha1(data)
+        local fname = pandoc.sha1(data) .. ".svg"
         pandoc.mediabag.insert(fname, "image/svg+xml", data)
         local dgr_opt = diagram_options(el, "#")
         local image = pandoc.Image(dgr_opt.alt, fname, "", dgr_opt["image-attr"])


### PR DESCRIPTION
### Лист изменений

- Расширения выходных изображений `pysvg` теперь проставляет автоматически. Вследствие этого из `mdbook.py` удалён код, использующий регулярные выражения для проставления расширений у сгенерированных картинок.
- Логика замены относительных ссылок на источники на абсолютные, включающие название страницы со списком литературы, перемещена в `mdbook.lua` для поддержки ссылок в подписях к рисункам и таблицам. Вследствие этого из `mdbook.py` была удалена соответствующая логика обработки текста на основе `re`.

Теперь единственной задачей `mdbook.py` является разбиение сгенерированного при помощи `pandoc` md-файла на страницы-подразделы.